### PR TITLE
feat: implement NestJS backend services

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/cpsrecord"
+PORT=3000

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,40 @@
+# CPS Record Backend
+
+基于 NestJS + Prisma + PostgreSQL 的项目内容管理系统后端实现，覆盖项目、子项目、内容类型、内容与文字口令的核心需求。
+
+## 开发说明
+
+1. 安装依赖
+
+```bash
+npm install
+```
+
+2. 配置环境变量
+
+复制 `.env.example` 为 `.env` 并填入数据库连接：
+
+```bash
+cp .env.example .env
+```
+
+3. 生成 Prisma Client 并执行数据库迁移
+
+```bash
+npm run prisma:generate
+npm run prisma:migrate
+```
+
+4. 运行开发服务器
+
+```bash
+npm run start:dev
+```
+
+5. 可选：种子数据
+
+```bash
+npm run seed
+```
+
+服务默认在 `http://localhost:3000` 运行，Swagger 文档位于 `http://localhost:3000/docs`。

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "cpsrecord-backend",
+  "version": "1.0.0",
+  "description": "CPS Record server backend",
+  "license": "MIT",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "nest build",
+    "start": "node dist/main.js",
+    "start:dev": "nest start --watch",
+    "lint": "eslint --ext .ts src",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "seed": "ts-node prisma/seed.ts",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.1.17",
+    "@prisma/client": "^5.9.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "helmet": "^7.0.0",
+    "nestjs-prisma": "^0.22.0",
+    "prisma": "^5.9.1",
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^5.0.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.5",
+    "@types/node": "^18.19.0",
+    "@types/supertest": "^2.0.12",
+    "eslint": "^8.50.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.0.0",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,88 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Project {
+  id          Int          @id @default(autoincrement())
+  name        String       @db.VarChar(255)
+  description String?
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
+  isActive    Boolean      @default(true) @map("is_active")
+
+  subProjects SubProject[]
+
+  @@map("projects")
+}
+
+model SubProject {
+  id          Int                 @id @default(autoincrement())
+  projectId   Int                 @map("project_id")
+  name        String              @db.VarChar(255)
+  description String?
+  sortOrder   Int                 @default(0) @map("sort_order")
+  createdAt   DateTime            @default(now()) @map("created_at")
+  updatedAt   DateTime            @updatedAt @map("updated_at")
+  isActive    Boolean             @default(true) @map("is_active")
+
+  project      Project             @relation(fields: [projectId], references: [id])
+  contents     SubProjectContent[]
+  textCommands TextCommand[]
+
+  @@map("sub_projects")
+  @@index([projectId])
+}
+
+model ContentType {
+  id        Int                 @id @default(autoincrement())
+  name      String              @unique @db.VarChar(100)
+  fieldType String              @map("field_type") @db.VarChar(50)
+  hasExpiry Boolean             @default(false) @map("has_expiry")
+  isSystem  Boolean             @default(false) @map("is_system")
+  createdAt DateTime            @default(now()) @map("created_at")
+
+  contents SubProjectContent[]
+
+  @@map("content_types")
+}
+
+model SubProjectContent {
+  id            Int       @id @default(autoincrement())
+  subProjectId  Int       @map("sub_project_id")
+  contentTypeId Int       @map("content_type_id")
+  contentValue  String?   @map("content_value")
+  expiryDays    Int?      @map("expiry_days")
+  expiryDate    DateTime? @map("expiry_date") @db.Date
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
+  isActive      Boolean   @default(true) @map("is_active")
+
+  subProject  SubProject  @relation(fields: [subProjectId], references: [id])
+  contentType ContentType @relation(fields: [contentTypeId], references: [id])
+
+  @@unique([subProjectId, contentTypeId])
+  @@map("sub_project_contents")
+  @@index([subProjectId])
+}
+
+model TextCommand {
+  id           Int      @id @default(autoincrement())
+  subProjectId Int      @map("sub_project_id")
+  commandText  String   @map("command_text")
+  expiryDays   Int?     @map("expiry_days")
+  expiryDate   DateTime? @map("expiry_date") @db.Date
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+  isActive     Boolean  @default(true) @map("is_active")
+
+  subProject SubProject @relation(fields: [subProjectId], references: [id])
+
+  @@map("text_commands")
+  @@index([subProjectId])
+  @@index([expiryDate])
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,56 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const project = await prisma.project.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      name: '默认项目',
+      description: '示例项目数据',
+    },
+  });
+
+  const subProject = await prisma.subProject.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      projectId: project.id,
+      name: '示例子项目',
+      description: '示例子项目描述',
+      sortOrder: 1,
+    },
+  });
+
+  await prisma.contentType.upsert({
+    where: { name: '链接' },
+    update: {},
+    create: {
+      name: '链接',
+      fieldType: 'url',
+      hasExpiry: true,
+      isSystem: true,
+    },
+  });
+
+  await prisma.subProjectContent.upsert({
+    where: { subProjectId_contentTypeId: { subProjectId: subProject.id, contentTypeId: 1 } },
+    update: { contentValue: 'https://example.com' },
+    create: {
+      subProjectId: subProject.id,
+      contentTypeId: 1,
+      contentValue: 'https://example.com',
+      expiryDays: 30,
+    },
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('健康检查')
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get('health')
+  getHealth() {
+    return this.appService.getHealth();
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { DatabaseModule } from './common/database/database.module';
+import { ProjectsModule } from './modules/projects/projects.module';
+import { SubProjectsModule } from './modules/sub-projects/sub-projects.module';
+import { ContentTypesModule } from './modules/content-types/content-types.module';
+import { ContentsModule } from './modules/contents/contents.module';
+import { TextCommandsModule } from './modules/text-commands/text-commands.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    DatabaseModule,
+    ProjectsModule,
+    SubProjectsModule,
+    ContentTypesModule,
+    ContentsModule,
+    TextCommandsModule,
+  ],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHealth() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class DatabaseModule {}

--- a/backend/src/common/database/prisma.service.ts
+++ b/backend/src/common/database/prisma.service.ts
@@ -1,0 +1,15 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/backend/src/common/decorators/api-response.decorator.ts
+++ b/backend/src/common/decorators/api-response.decorator.ts
@@ -1,0 +1,23 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiResponse, ApiResponseOptions } from '@nestjs/swagger';
+
+interface ApiResponseWrapperOptions extends ApiResponseOptions {
+  type?: 'array' | 'object';
+}
+
+export function ApiResponseWrapper(options: ApiResponseWrapperOptions) {
+  return applyDecorators(
+    ApiResponse({
+      ...options,
+      schema: {
+        properties: {
+          success: { type: 'boolean', example: true },
+          message: { type: 'string', example: options.description ?? 'success' },
+          data: options.type === 'array'
+            ? { type: 'array', items: { type: 'object' } }
+            : { type: 'object' },
+        },
+      },
+    }),
+  );
+}

--- a/backend/src/common/filters/http-exception.filter.ts
+++ b/backend/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,41 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = 'Internal server error';
+
+    if (exception instanceof HttpException) {
+      status = exception.getStatus();
+      const res = exception.getResponse();
+      message =
+        typeof res === 'string'
+          ? res
+          : (res as Record<string, any>).message ?? message;
+    }
+
+    this.logger.error(
+      `${request.method} ${request.url} -> ${status}: ${JSON.stringify(message)}`,
+    );
+
+    response.status(status).json({
+      success: false,
+      message,
+      data: null,
+    });
+  }
+}

--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -1,0 +1,32 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(LoggingInterceptor.name);
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const { method, url } = request;
+    const now = Date.now();
+    this.logger.log(`${method} ${url} - Request received`);
+
+    return next.handle().pipe(
+      tap({
+        next: () =>
+          this.logger.log(`${method} ${url} - Completed in ${Date.now() - now}ms`),
+        error: (error) =>
+          this.logger.error(
+            `${method} ${url} - Failed in ${Date.now() - now}ms: ${error.message}`,
+          ),
+      }),
+    );
+  }
+}

--- a/backend/src/common/interceptors/response.interceptor.ts
+++ b/backend/src/common/interceptors/response.interceptor.ts
@@ -1,0 +1,32 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+interface Response<T> {
+  data: T;
+  message: string;
+  success: boolean;
+}
+
+@Injectable()
+export class ResponseInterceptor<T>
+  implements NestInterceptor<T, Response<T>>
+{
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<Response<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        data,
+        success: true,
+        message: 'success',
+      })),
+    );
+  }
+}

--- a/backend/src/common/pipes/validation.pipe.ts
+++ b/backend/src/common/pipes/validation.pipe.ts
@@ -1,0 +1,32 @@
+import {
+  ArgumentMetadata,
+  Injectable,
+  PipeTransform,
+  BadRequestException,
+} from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+@Injectable()
+export class CustomValidationPipe implements PipeTransform<any> {
+  async transform(value: any, { metatype }: ArgumentMetadata) {
+    if (!metatype || !this.toValidate(metatype)) {
+      return value;
+    }
+
+    const object = plainToInstance(metatype, value);
+    const errors = await validate(object);
+    if (errors.length > 0) {
+      const messages = errors
+        .map((err) => Object.values(err.constraints ?? {}))
+        .flat();
+      throw new BadRequestException(messages);
+    }
+    return object;
+  }
+
+  private toValidate(metatype: any): boolean {
+    const types: any[] = [String, Boolean, Number, Array, Object];
+    return !types.includes(metatype);
+  }
+}

--- a/backend/src/common/utils/date.util.ts
+++ b/backend/src/common/utils/date.util.ts
@@ -1,0 +1,9 @@
+export function calculateExpiryDate(days?: number | null): Date | null {
+  if (!days && days !== 0) {
+    return null;
+  }
+  const now = new Date();
+  const expiry = new Date(now);
+  expiry.setDate(now.getDate() + days);
+  return expiry;
+}

--- a/backend/src/common/utils/response.util.ts
+++ b/backend/src/common/utils/response.util.ts
@@ -1,0 +1,20 @@
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export function buildPaginationResponse<T>(
+  items: T[],
+  total: number,
+  page: number,
+  limit: number,
+): PaginatedResult<T> {
+  return {
+    items,
+    total,
+    page,
+    limit,
+  };
+}

--- a/backend/src/config/app.config.ts
+++ b/backend/src/config/app.config.ts
@@ -1,0 +1,5 @@
+export default () => ({
+  app: {
+    port: parseInt(process.env.PORT ?? '3000', 10),
+  },
+});

--- a/backend/src/config/database.config.ts
+++ b/backend/src/config/database.config.ts
@@ -1,0 +1,5 @@
+export default () => ({
+  database: {
+    url: process.env.DATABASE_URL ?? '',
+  },
+});

--- a/backend/src/config/swagger.config.ts
+++ b/backend/src/config/swagger.config.ts
@@ -1,0 +1,8 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+
+export const buildSwaggerConfig = () =>
+  new DocumentBuilder()
+    .setTitle('CPS Record API')
+    .setDescription('API documentation for CPS Record management system')
+    .setVersion('1.0.0')
+    .build();

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,35 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import helmet from 'helmet';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  app.use(helmet());
+  app.setGlobalPrefix('api');
+  app.enableCors();
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+    }),
+  );
+
+  const config = new DocumentBuilder()
+    .setTitle('CPS Record API')
+    .setDescription('API documentation for CPS Record content management system')
+    .setVersion('1.0.0')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('docs', app, document);
+
+  const port = process.env.PORT || 3000;
+  await app.listen(port);
+}
+
+bootstrap();

--- a/backend/src/modules/content-types/content-types.controller.ts
+++ b/backend/src/modules/content-types/content-types.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ResponseInterceptor } from '../../common/interceptors/response.interceptor';
+import { ApiResponseWrapper } from '../../common/decorators/api-response.decorator';
+import { ContentTypesService } from './content-types.service';
+import { CreateContentTypeDto } from './dto/create-content-type.dto';
+import { UpdateContentTypeDto } from './dto/update-content-type.dto';
+
+@ApiTags('内容类型管理')
+@Controller('content-types')
+@UseInterceptors(ResponseInterceptor)
+export class ContentTypesController {
+  constructor(private readonly contentTypesService: ContentTypesService) {}
+
+  @Get()
+  @ApiOperation({ summary: '获取内容类型列表' })
+  @ApiResponseWrapper({ status: 200, description: '获取内容类型列表成功', type: 'array' })
+  async findAll() {
+    return this.contentTypesService.findAll();
+  }
+
+  @Post()
+  @ApiOperation({ summary: '创建内容类型' })
+  @ApiResponseWrapper({ status: 201, description: '创建内容类型成功' })
+  async create(@Body() dto: CreateContentTypeDto) {
+    return this.contentTypesService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: '更新内容类型' })
+  @ApiResponseWrapper({ status: 200, description: '更新内容类型成功' })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateContentTypeDto,
+  ) {
+    return this.contentTypesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '删除内容类型' })
+  @ApiResponseWrapper({ status: 200, description: '删除内容类型成功' })
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    return this.contentTypesService.remove(id);
+  }
+}

--- a/backend/src/modules/content-types/content-types.module.ts
+++ b/backend/src/modules/content-types/content-types.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ContentTypesController } from './content-types.controller';
+import { ContentTypesService } from './content-types.service';
+
+@Module({
+  controllers: [ContentTypesController],
+  providers: [ContentTypesService],
+  exports: [ContentTypesService],
+})
+export class ContentTypesModule {}

--- a/backend/src/modules/content-types/content-types.service.ts
+++ b/backend/src/modules/content-types/content-types.service.ts
@@ -1,0 +1,80 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../../common/database/prisma.service';
+import { CreateContentTypeDto } from './dto/create-content-type.dto';
+import { UpdateContentTypeDto } from './dto/update-content-type.dto';
+
+@Injectable()
+export class ContentTypesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll() {
+    return this.prisma.contentType.findMany({
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async create(dto: CreateContentTypeDto) {
+    const existing = await this.prisma.contentType.findUnique({
+      where: { name: dto.name },
+    });
+
+    if (existing) {
+      throw new BadRequestException('内容类型名称已存在');
+    }
+
+    return this.prisma.contentType.create({ data: dto });
+  }
+
+  async update(id: number, dto: UpdateContentTypeDto) {
+    const type = await this.ensureExists(id);
+
+    if (type.isSystem && dto.name && dto.name !== type.name) {
+      throw new BadRequestException('系统内置类型名称不可修改');
+    }
+
+    if (dto.name && dto.name !== type.name) {
+      const exists = await this.prisma.contentType.findUnique({
+        where: { name: dto.name },
+      });
+      if (exists) {
+        throw new BadRequestException('内容类型名称已存在');
+      }
+    }
+
+    return this.prisma.contentType.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  async remove(id: number) {
+    const type = await this.ensureExists(id);
+
+    if (type.isSystem) {
+      throw new BadRequestException('系统内置类型不可删除');
+    }
+
+    const usage = await this.prisma.subProjectContent.count({
+      where: { contentTypeId: id, isActive: true },
+    });
+
+    if (usage > 0) {
+      throw new BadRequestException('内容类型被内容使用，无法删除');
+    }
+
+    await this.prisma.contentType.delete({ where: { id } });
+    return { message: '内容类型删除成功' };
+  }
+
+  private async ensureExists(id: number) {
+    const type = await this.prisma.contentType.findUnique({ where: { id } });
+    if (!type) {
+      throw new NotFoundException('内容类型不存在');
+    }
+    return type;
+  }
+}

--- a/backend/src/modules/content-types/dto/create-content-type.dto.ts
+++ b/backend/src/modules/content-types/dto/create-content-type.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString, Length } from 'class-validator';
+
+export class CreateContentTypeDto {
+  @ApiProperty({ description: '类型名称', example: '图片链接' })
+  @IsString({ message: '类型名称必须是字符串' })
+  @Length(1, 100, { message: '类型名称长度必须在1-100个字符之间' })
+  name!: string;
+
+  @ApiProperty({ description: '字段类型', example: 'url' })
+  @IsString({ message: '字段类型必须是字符串' })
+  @Length(1, 50, { message: '字段类型长度必须在1-50个字符之间' })
+  fieldType!: string;
+
+  @ApiProperty({ description: '是否需要设置有效期', default: false, required: false })
+  @IsOptional()
+  @IsBoolean({ message: '是否需要设置有效期必须是布尔值' })
+  hasExpiry?: boolean = false;
+
+  @ApiProperty({ description: '是否系统内置类型', default: false, required: false })
+  @IsOptional()
+  @IsBoolean({ message: '是否系统内置类型必须是布尔值' })
+  isSystem?: boolean = false;
+}

--- a/backend/src/modules/content-types/dto/update-content-type.dto.ts
+++ b/backend/src/modules/content-types/dto/update-content-type.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateContentTypeDto } from './create-content-type.dto';
+
+export class UpdateContentTypeDto extends PartialType(CreateContentTypeDto) {}

--- a/backend/src/modules/contents/contents.controller.ts
+++ b/backend/src/modules/contents/contents.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ResponseInterceptor } from '../../common/interceptors/response.interceptor';
+import { ApiResponseWrapper } from '../../common/decorators/api-response.decorator';
+import { ContentsService } from './contents.service';
+import { CreateContentDto } from './dto/create-content.dto';
+import { UpdateContentDto } from './dto/update-content.dto';
+import { QueryContentDto } from './dto/query-content.dto';
+
+@ApiTags('内容管理')
+@Controller('contents')
+@UseInterceptors(ResponseInterceptor)
+export class ContentsController {
+  constructor(private readonly contentsService: ContentsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '获取子项目内容列表' })
+  @ApiQuery({ name: 'subProjectId', required: false, type: Number, description: '子项目ID' })
+  @ApiResponseWrapper({ status: 200, description: '获取内容列表成功', type: 'array' })
+  async findAll(@Query() query: QueryContentDto) {
+    return this.contentsService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '获取子项目内容详情' })
+  @ApiResponseWrapper({ status: 200, description: '获取内容详情成功' })
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.contentsService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: '创建子项目内容' })
+  @ApiResponseWrapper({ status: 201, description: '创建内容成功' })
+  async create(@Body() dto: CreateContentDto) {
+    return this.contentsService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: '更新子项目内容' })
+  @ApiResponseWrapper({ status: 200, description: '更新内容成功' })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateContentDto,
+  ) {
+    return this.contentsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '删除子项目内容' })
+  @ApiResponseWrapper({ status: 200, description: '删除内容成功' })
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    return this.contentsService.remove(id);
+  }
+}

--- a/backend/src/modules/contents/contents.module.ts
+++ b/backend/src/modules/contents/contents.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ContentsController } from './contents.controller';
+import { ContentsService } from './contents.service';
+
+@Module({
+  controllers: [ContentsController],
+  providers: [ContentsService],
+})
+export class ContentsModule {}

--- a/backend/src/modules/contents/contents.service.ts
+++ b/backend/src/modules/contents/contents.service.ts
@@ -1,0 +1,141 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../../common/database/prisma.service';
+import { CreateContentDto } from './dto/create-content.dto';
+import { UpdateContentDto } from './dto/update-content.dto';
+import { QueryContentDto } from './dto/query-content.dto';
+import { calculateExpiryDate } from '../../common/utils/date.util';
+
+@Injectable()
+export class ContentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(query: QueryContentDto) {
+    const { subProjectId } = query;
+
+    return this.prisma.subProjectContent.findMany({
+      where: {
+        isActive: true,
+        ...(subProjectId ? { subProjectId } : {}),
+      },
+      include: { contentType: true, subProject: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findOne(id: number) {
+    const content = await this.prisma.subProjectContent.findFirst({
+      where: { id, isActive: true },
+      include: { contentType: true, subProject: true },
+    });
+
+    if (!content) {
+      throw new NotFoundException('子项目内容不存在');
+    }
+
+    return content;
+  }
+
+  async create(dto: CreateContentDto) {
+    await this.ensureSubProjectExists(dto.subProjectId);
+    await this.ensureContentTypeExists(dto.contentTypeId);
+
+    const existing = await this.prisma.subProjectContent.findFirst({
+      where: {
+        subProjectId: dto.subProjectId,
+        contentTypeId: dto.contentTypeId,
+        isActive: true,
+      },
+    });
+
+    if (existing) {
+      throw new BadRequestException('该子项目已存在相同类型的内容');
+    }
+
+    return this.prisma.subProjectContent.create({
+      data: {
+        subProject: { connect: { id: dto.subProjectId } },
+        contentType: { connect: { id: dto.contentTypeId } },
+        contentValue: dto.contentValue,
+        expiryDays: dto.expiryDays,
+        expiryDate: calculateExpiryDate(dto.expiryDays) ?? undefined,
+      },
+      include: { contentType: true, subProject: true },
+    });
+  }
+
+  async update(id: number, dto: UpdateContentDto) {
+    const content = await this.ensureExists(id);
+
+    if (dto.contentTypeId && dto.contentTypeId !== content.contentTypeId) {
+      await this.ensureContentTypeExists(dto.contentTypeId);
+      const duplicate = await this.prisma.subProjectContent.findFirst({
+        where: {
+          subProjectId: content.subProjectId,
+          contentTypeId: dto.contentTypeId,
+          isActive: true,
+          NOT: { id },
+        },
+      });
+      if (duplicate) {
+        throw new BadRequestException('该子项目已存在相同类型的内容');
+      }
+    }
+
+    return this.prisma.subProjectContent.update({
+      where: { id },
+      data: {
+        contentTypeId: dto.contentTypeId,
+        contentValue: dto.contentValue,
+        expiryDays: dto.expiryDays ?? content.expiryDays,
+        expiryDate:
+          dto.expiryDays !== undefined
+            ? calculateExpiryDate(dto.expiryDays) ?? undefined
+            : content.expiryDate,
+      },
+      include: { contentType: true, subProject: true },
+    });
+  }
+
+  async remove(id: number) {
+    await this.ensureExists(id);
+
+    await this.prisma.subProjectContent.update({
+      where: { id },
+      data: { isActive: false },
+    });
+
+    return { message: '子项目内容删除成功' };
+  }
+
+  private async ensureExists(id: number) {
+    const content = await this.prisma.subProjectContent.findFirst({
+      where: { id, isActive: true },
+    });
+    if (!content) {
+      throw new NotFoundException('子项目内容不存在');
+    }
+    return content;
+  }
+
+  private async ensureSubProjectExists(subProjectId: number) {
+    const subProject = await this.prisma.subProject.findFirst({
+      where: { id: subProjectId, isActive: true },
+    });
+    if (!subProject) {
+      throw new NotFoundException('子项目不存在');
+    }
+  }
+
+  private async ensureContentTypeExists(contentTypeId: number) {
+    const contentType = await this.prisma.contentType.findUnique({
+      where: { id: contentTypeId },
+    });
+    if (!contentType) {
+      throw new NotFoundException('内容类型不存在');
+    }
+  }
+}

--- a/backend/src/modules/contents/dto/create-content.dto.ts
+++ b/backend/src/modules/contents/dto/create-content.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  Length,
+  Min,
+} from 'class-validator';
+
+export class CreateContentDto {
+  @ApiProperty({ description: '子项目ID', example: 1 })
+  @Type(() => Number)
+  @IsInt({ message: '子项目ID必须是整数' })
+  @Min(1, { message: '子项目ID必须大于0' })
+  subProjectId!: number;
+
+  @ApiProperty({ description: '内容类型ID', example: 1 })
+  @Type(() => Number)
+  @IsInt({ message: '内容类型ID必须是整数' })
+  @Min(1, { message: '内容类型ID必须大于0' })
+  contentTypeId!: number;
+
+  @ApiProperty({ description: '内容值', example: 'https://example.com/image.jpg' })
+  @IsString({ message: '内容值必须是字符串' })
+  @Length(1, 2000, { message: '内容值长度必须在1-2000个字符之间' })
+  contentValue!: string;
+
+  @ApiProperty({ description: '有效天数', example: 30, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '有效天数必须是整数' })
+  @Min(1, { message: '有效天数必须大于0' })
+  expiryDays?: number;
+}

--- a/backend/src/modules/contents/dto/query-content.dto.ts
+++ b/backend/src/modules/contents/dto/query-content.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class QueryContentDto {
+  @ApiProperty({ description: '子项目ID', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '子项目ID必须是整数' })
+  @Min(1, { message: '子项目ID必须大于0' })
+  subProjectId?: number;
+}

--- a/backend/src/modules/contents/dto/update-content.dto.ts
+++ b/backend/src/modules/contents/dto/update-content.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateContentDto } from './create-content.dto';
+
+export class UpdateContentDto extends PartialType(CreateContentDto) {}

--- a/backend/src/modules/projects/dto/create-project.dto.ts
+++ b/backend/src/modules/projects/dto/create-project.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, Length } from 'class-validator';
+
+export class CreateProjectDto {
+  @ApiProperty({ description: '项目名称', example: '淘宝CPS推广' })
+  @IsString({ message: '项目名称必须是字符串' })
+  @Length(1, 255, { message: '项目名称长度必须在1-255个字符之间' })
+  name!: string;
+
+  @ApiProperty({
+    description: '项目描述',
+    example: '主要推广淘宝商品，包含服装、数码等分类',
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ message: '项目描述必须是字符串' })
+  @Length(0, 1000, { message: '项目描述长度不能超过1000个字符' })
+  description?: string;
+}

--- a/backend/src/modules/projects/dto/query-project.dto.ts
+++ b/backend/src/modules/projects/dto/query-project.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class QueryProjectDto {
+  @ApiProperty({ description: '页码', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '页码必须是整数' })
+  @Min(1, { message: '页码必须大于0' })
+  page: number = 1;
+
+  @ApiProperty({ description: '每页数量', example: 10, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '每页数量必须是整数' })
+  @Min(1, { message: '每页数量必须大于0' })
+  @Max(100, { message: '每页数量不能超过100' })
+  limit: number = 10;
+
+  @ApiProperty({ description: '搜索关键词', required: false })
+  @IsOptional()
+  @IsString({ message: '搜索关键词必须是字符串' })
+  search?: string;
+}

--- a/backend/src/modules/projects/dto/update-project.dto.ts
+++ b/backend/src/modules/projects/dto/update-project.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProjectDto } from './create-project.dto';
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {}

--- a/backend/src/modules/projects/projects.controller.ts
+++ b/backend/src/modules/projects/projects.controller.ts
@@ -1,0 +1,84 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ResponseInterceptor } from '../../common/interceptors/response.interceptor';
+import { ApiResponseWrapper } from '../../common/decorators/api-response.decorator';
+import { ProjectsService } from './projects.service';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+import { QueryProjectDto } from './dto/query-project.dto';
+
+@ApiTags('项目管理')
+@Controller('projects')
+@UseInterceptors(ResponseInterceptor)
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '获取项目列表' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: '页码' })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: '每页数量',
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: '搜索关键词',
+  })
+  @ApiResponseWrapper({ status: 200, description: '获取项目列表成功', type: 'object' })
+  async findAll(@Query() query: QueryProjectDto) {
+    return this.projectsService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '获取项目详情' })
+  @ApiResponseWrapper({ status: 200, description: '获取项目详情成功' })
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.projectsService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: '创建项目' })
+  @ApiResponseWrapper({ status: 201, description: '创建项目成功' })
+  async create(@Body() dto: CreateProjectDto) {
+    return this.projectsService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: '更新项目' })
+  @ApiResponseWrapper({ status: 200, description: '更新项目成功' })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateProjectDto,
+  ) {
+    return this.projectsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '删除项目' })
+  @ApiResponseWrapper({ status: 200, description: '删除项目成功' })
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    return this.projectsService.remove(id);
+  }
+
+  @Get(':id/sub-projects')
+  @ApiOperation({ summary: '获取项目的子项目列表' })
+  @ApiResponseWrapper({ status: 200, description: '获取子项目列表成功', type: 'array' })
+  async getSubProjects(@Param('id', ParseIntPipe) id: number) {
+    return this.projectsService.getSubProjects(id);
+  }
+}

--- a/backend/src/modules/projects/projects.module.ts
+++ b/backend/src/modules/projects/projects.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { ProjectsController } from './projects.controller';
+
+@Module({
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+  exports: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/backend/src/modules/projects/projects.service.ts
+++ b/backend/src/modules/projects/projects.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../common/database/prisma.service';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+import { QueryProjectDto } from './dto/query-project.dto';
+import { buildPaginationResponse } from '../../common/utils/response.util';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class ProjectsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(query: QueryProjectDto) {
+    const { page = 1, limit = 10, search } = query;
+
+    const where: Prisma.ProjectWhereInput = {
+      isActive: true,
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { description: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, items] = await this.prisma.$transaction([
+      this.prisma.project.count({ where }),
+      this.prisma.project.findMany({
+        where,
+        orderBy: { updatedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        include: {
+          _count: { select: { subProjects: { where: { isActive: true } } } },
+        },
+      }),
+    ]);
+
+    return buildPaginationResponse(items, total, page, limit);
+  }
+
+  async findOne(id: number) {
+    const project = await this.prisma.project.findFirst({
+      where: { id, isActive: true },
+      include: {
+        subProjects: {
+          where: { isActive: true },
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+
+    if (!project) {
+      throw new NotFoundException('项目不存在');
+    }
+
+    return project;
+  }
+
+  async create(createProjectDto: CreateProjectDto) {
+    return this.prisma.project.create({ data: createProjectDto });
+  }
+
+  async update(id: number, updateProjectDto: UpdateProjectDto) {
+    await this.ensureExists(id);
+
+    return this.prisma.project.update({
+      where: { id },
+      data: updateProjectDto,
+    });
+  }
+
+  async remove(id: number) {
+    await this.ensureExists(id);
+
+    await this.prisma.$transaction([
+      this.prisma.subProjectContent.updateMany({
+        where: { subProject: { projectId: id } },
+        data: { isActive: false },
+      }),
+      this.prisma.textCommand.updateMany({
+        where: { subProject: { projectId: id } },
+        data: { isActive: false },
+      }),
+      this.prisma.subProject.updateMany({
+        where: { projectId: id },
+        data: { isActive: false },
+      }),
+      this.prisma.project.update({
+        where: { id },
+        data: { isActive: false },
+      }),
+    ]);
+
+    return { message: '项目删除成功' };
+  }
+
+  async getSubProjects(projectId: number) {
+    await this.ensureExists(projectId);
+
+    return this.prisma.subProject.findMany({
+      where: { projectId, isActive: true },
+      orderBy: { sortOrder: 'asc' },
+      include: {
+        contents: {
+          where: { isActive: true },
+          include: { contentType: true },
+        },
+        textCommands: {
+          where: { isActive: true },
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
+  }
+
+  private async ensureExists(id: number) {
+    const exists = await this.prisma.project.findFirst({
+      where: { id, isActive: true },
+      select: { id: true },
+    });
+
+    if (!exists) {
+      throw new NotFoundException('项目不存在');
+    }
+  }
+}

--- a/backend/src/modules/sub-projects/dto/create-sub-project.dto.ts
+++ b/backend/src/modules/sub-projects/dto/create-sub-project.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Length, Min } from 'class-validator';
+
+export class CreateSubProjectDto {
+  @ApiProperty({ description: '所属项目ID', example: 1 })
+  @Type(() => Number)
+  @IsInt({ message: '项目ID必须是整数' })
+  @Min(1, { message: '项目ID必须大于0' })
+  projectId!: number;
+
+  @ApiProperty({ description: '子项目名称', example: '服装类目' })
+  @IsString({ message: '子项目名称必须是字符串' })
+  @Length(1, 255, { message: '子项目名称长度必须在1-255个字符之间' })
+  name!: string;
+
+  @ApiProperty({ description: '子项目描述', required: false })
+  @IsOptional()
+  @IsString({ message: '子项目描述必须是字符串' })
+  @Length(0, 1000, { message: '子项目描述长度不能超过1000个字符' })
+  description?: string;
+
+  @ApiProperty({ description: '排序序号', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '排序序号必须是整数' })
+  sortOrder?: number;
+}

--- a/backend/src/modules/sub-projects/dto/query-sub-project.dto.ts
+++ b/backend/src/modules/sub-projects/dto/query-sub-project.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class QuerySubProjectDto {
+  @ApiProperty({ description: '所属项目ID', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '项目ID必须是整数' })
+  @Min(1, { message: '项目ID必须大于0' })
+  projectId?: number;
+
+  @ApiProperty({ description: '搜索关键词', required: false })
+  @IsOptional()
+  @IsString({ message: '搜索关键词必须是字符串' })
+  search?: string;
+}

--- a/backend/src/modules/sub-projects/dto/reorder-sub-project.dto.ts
+++ b/backend/src/modules/sub-projects/dto/reorder-sub-project.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, IsInt, Min, ValidateNested } from 'class-validator';
+
+class SubProjectOrderItem {
+  @ApiProperty({ description: '子项目ID', example: 1 })
+  @Type(() => Number)
+  @IsInt({ message: '子项目ID必须是整数' })
+  @Min(1, { message: '子项目ID必须大于0' })
+  id!: number;
+
+  @ApiProperty({ description: '排序值', example: 1 })
+  @Type(() => Number)
+  @IsInt({ message: '排序值必须是整数' })
+  sortOrder!: number;
+}
+
+export class ReorderSubProjectDto {
+  @ApiProperty({
+    description: '排序数据',
+    type: [SubProjectOrderItem],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => SubProjectOrderItem)
+  items!: SubProjectOrderItem[];
+}

--- a/backend/src/modules/sub-projects/dto/update-sub-project.dto.ts
+++ b/backend/src/modules/sub-projects/dto/update-sub-project.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSubProjectDto } from './create-sub-project.dto';
+
+export class UpdateSubProjectDto extends PartialType(CreateSubProjectDto) {}

--- a/backend/src/modules/sub-projects/sub-projects.controller.ts
+++ b/backend/src/modules/sub-projects/sub-projects.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ResponseInterceptor } from '../../common/interceptors/response.interceptor';
+import { ApiResponseWrapper } from '../../common/decorators/api-response.decorator';
+import { SubProjectsService } from './sub-projects.service';
+import { CreateSubProjectDto } from './dto/create-sub-project.dto';
+import { UpdateSubProjectDto } from './dto/update-sub-project.dto';
+import { QuerySubProjectDto } from './dto/query-sub-project.dto';
+import { ReorderSubProjectDto } from './dto/reorder-sub-project.dto';
+
+@ApiTags('子项目管理')
+@Controller('sub-projects')
+@UseInterceptors(ResponseInterceptor)
+export class SubProjectsController {
+  constructor(private readonly subProjectsService: SubProjectsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '获取子项目列表' })
+  @ApiQuery({ name: 'projectId', required: false, type: Number, description: '项目ID' })
+  @ApiQuery({ name: 'search', required: false, type: String, description: '搜索关键词' })
+  @ApiResponseWrapper({ status: 200, description: '获取子项目列表成功', type: 'array' })
+  async findAll(@Query() query: QuerySubProjectDto) {
+    return this.subProjectsService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '获取子项目详情' })
+  @ApiResponseWrapper({ status: 200, description: '获取子项目详情成功' })
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.subProjectsService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: '创建子项目' })
+  @ApiResponseWrapper({ status: 201, description: '创建子项目成功' })
+  async create(@Body() dto: CreateSubProjectDto) {
+    return this.subProjectsService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: '更新子项目' })
+  @ApiResponseWrapper({ status: 200, description: '更新子项目成功' })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateSubProjectDto,
+  ) {
+    return this.subProjectsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '删除子项目' })
+  @ApiResponseWrapper({ status: 200, description: '删除子项目成功' })
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    return this.subProjectsService.remove(id);
+  }
+
+  @Post('reorder')
+  @ApiOperation({ summary: '更新子项目排序' })
+  @ApiResponseWrapper({ status: 200, description: '子项目排序更新成功' })
+  async reorder(@Body() dto: ReorderSubProjectDto) {
+    return this.subProjectsService.reorder(dto);
+  }
+}

--- a/backend/src/modules/sub-projects/sub-projects.module.ts
+++ b/backend/src/modules/sub-projects/sub-projects.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SubProjectsController } from './sub-projects.controller';
+import { SubProjectsService } from './sub-projects.service';
+
+@Module({
+  controllers: [SubProjectsController],
+  providers: [SubProjectsService],
+  exports: [SubProjectsService],
+})
+export class SubProjectsModule {}

--- a/backend/src/modules/sub-projects/sub-projects.service.ts
+++ b/backend/src/modules/sub-projects/sub-projects.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../common/database/prisma.service';
+import { CreateSubProjectDto } from './dto/create-sub-project.dto';
+import { UpdateSubProjectDto } from './dto/update-sub-project.dto';
+import { QuerySubProjectDto } from './dto/query-sub-project.dto';
+import { ReorderSubProjectDto } from './dto/reorder-sub-project.dto';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class SubProjectsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(query: QuerySubProjectDto) {
+    const { projectId, search } = query;
+
+    const where: Prisma.SubProjectWhereInput = {
+      isActive: true,
+      ...(projectId ? { projectId } : {}),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { description: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    return this.prisma.subProject.findMany({
+      where,
+      orderBy: { sortOrder: 'asc' },
+      include: {
+        project: true,
+        contents: { where: { isActive: true }, include: { contentType: true } },
+        textCommands: { where: { isActive: true } },
+      },
+    });
+  }
+
+  async findOne(id: number) {
+    const subProject = await this.prisma.subProject.findFirst({
+      where: { id, isActive: true },
+      include: {
+        project: true,
+        contents: { where: { isActive: true }, include: { contentType: true } },
+        textCommands: { where: { isActive: true } },
+      },
+    });
+
+    if (!subProject) {
+      throw new NotFoundException('子项目不存在');
+    }
+
+    return subProject;
+  }
+
+  async create(dto: CreateSubProjectDto) {
+    await this.ensureProjectExists(dto.projectId);
+
+    const { projectId, sortOrder, ...rest } = dto;
+    return this.prisma.subProject.create({
+      data: {
+        ...rest,
+        project: { connect: { id: projectId } },
+        sortOrder: sortOrder ?? (await this.getNextSortOrder(projectId)),
+      },
+    });
+  }
+
+  async update(id: number, dto: UpdateSubProjectDto) {
+    const subProject = await this.ensureExists(id);
+
+    return this.prisma.subProject.update({
+      where: { id: subProject.id },
+      data: {
+        name: dto.name ?? subProject.name,
+        description: dto.description ?? subProject.description,
+        sortOrder: dto.sortOrder ?? subProject.sortOrder,
+      },
+    });
+  }
+
+  async remove(id: number) {
+    await this.ensureExists(id);
+
+    await this.prisma.$transaction([
+      this.prisma.subProjectContent.updateMany({
+        where: { subProjectId: id },
+        data: { isActive: false },
+      }),
+      this.prisma.textCommand.updateMany({
+        where: { subProjectId: id },
+        data: { isActive: false },
+      }),
+      this.prisma.subProject.update({
+        where: { id },
+        data: { isActive: false },
+      }),
+    ]);
+
+    return { message: '子项目删除成功' };
+  }
+
+  async reorder(dto: ReorderSubProjectDto) {
+    const updates = dto.items.map((item) =>
+      this.prisma.subProject.update({
+        where: { id: item.id },
+        data: { sortOrder: item.sortOrder },
+      }),
+    );
+
+    await this.prisma.$transaction(updates);
+    return { message: '子项目排序更新成功' };
+  }
+
+  private async ensureExists(id: number) {
+    const subProject = await this.prisma.subProject.findFirst({
+      where: { id, isActive: true },
+    });
+
+    if (!subProject) {
+      throw new NotFoundException('子项目不存在');
+    }
+
+    return subProject;
+  }
+
+  private async ensureProjectExists(projectId: number) {
+    const project = await this.prisma.project.findFirst({
+      where: { id: projectId, isActive: true },
+    });
+
+    if (!project) {
+      throw new NotFoundException('所属项目不存在');
+    }
+  }
+
+  private async getNextSortOrder(projectId: number) {
+    const latest = await this.prisma.subProject.findFirst({
+      where: { projectId, isActive: true },
+      orderBy: { sortOrder: 'desc' },
+      select: { sortOrder: true },
+    });
+
+    return (latest?.sortOrder ?? 0) + 1;
+  }
+}

--- a/backend/src/modules/text-commands/dto/create-text-command.dto.ts
+++ b/backend/src/modules/text-commands/dto/create-text-command.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Length, Min } from 'class-validator';
+
+export class CreateTextCommandDto {
+  @ApiProperty({ description: '子项目ID', example: 1 })
+  @Type(() => Number)
+  @IsInt({ message: '子项目ID必须是整数' })
+  @Min(1, { message: '子项目ID必须大于0' })
+  subProjectId!: number;
+
+  @ApiProperty({ description: '文字口令内容', example: '复制这段代码打开淘宝即可' })
+  @IsString({ message: '文字口令必须是字符串' })
+  @Length(1, 1000, { message: '文字口令长度必须在1-1000个字符之间' })
+  commandText!: string;
+
+  @ApiProperty({ description: '有效天数', example: 7, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '有效天数必须是整数' })
+  @Min(1, { message: '有效天数必须大于0' })
+  expiryDays?: number;
+}

--- a/backend/src/modules/text-commands/dto/query-text-command.dto.ts
+++ b/backend/src/modules/text-commands/dto/query-text-command.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class QueryTextCommandDto {
+  @ApiProperty({ description: '子项目ID', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: '子项目ID必须是整数' })
+  @Min(1, { message: '子项目ID必须大于0' })
+  subProjectId?: number;
+}

--- a/backend/src/modules/text-commands/dto/update-text-command.dto.ts
+++ b/backend/src/modules/text-commands/dto/update-text-command.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateTextCommandDto } from './create-text-command.dto';
+
+export class UpdateTextCommandDto extends PartialType(CreateTextCommandDto) {}

--- a/backend/src/modules/text-commands/text-commands.controller.ts
+++ b/backend/src/modules/text-commands/text-commands.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ResponseInterceptor } from '../../common/interceptors/response.interceptor';
+import { ApiResponseWrapper } from '../../common/decorators/api-response.decorator';
+import { TextCommandsService } from './text-commands.service';
+import { CreateTextCommandDto } from './dto/create-text-command.dto';
+import { UpdateTextCommandDto } from './dto/update-text-command.dto';
+import { QueryTextCommandDto } from './dto/query-text-command.dto';
+
+@ApiTags('文字口令管理')
+@Controller('text-commands')
+@UseInterceptors(ResponseInterceptor)
+export class TextCommandsController {
+  constructor(private readonly textCommandsService: TextCommandsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '获取文字口令列表' })
+  @ApiQuery({ name: 'subProjectId', required: false, type: Number, description: '子项目ID' })
+  @ApiResponseWrapper({ status: 200, description: '获取文字口令列表成功', type: 'array' })
+  async findAll(@Query() query: QueryTextCommandDto) {
+    return this.textCommandsService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '获取文字口令详情' })
+  @ApiResponseWrapper({ status: 200, description: '获取文字口令详情成功' })
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.textCommandsService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: '创建文字口令' })
+  @ApiResponseWrapper({ status: 201, description: '创建文字口令成功' })
+  async create(@Body() dto: CreateTextCommandDto) {
+    return this.textCommandsService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: '更新文字口令' })
+  @ApiResponseWrapper({ status: 200, description: '更新文字口令成功' })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateTextCommandDto,
+  ) {
+    return this.textCommandsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '删除文字口令' })
+  @ApiResponseWrapper({ status: 200, description: '删除文字口令成功' })
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    return this.textCommandsService.remove(id);
+  }
+}

--- a/backend/src/modules/text-commands/text-commands.module.ts
+++ b/backend/src/modules/text-commands/text-commands.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TextCommandsController } from './text-commands.controller';
+import { TextCommandsService } from './text-commands.service';
+
+@Module({
+  controllers: [TextCommandsController],
+  providers: [TextCommandsService],
+})
+export class TextCommandsModule {}

--- a/backend/src/modules/text-commands/text-commands.service.ts
+++ b/backend/src/modules/text-commands/text-commands.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../common/database/prisma.service';
+import { CreateTextCommandDto } from './dto/create-text-command.dto';
+import { UpdateTextCommandDto } from './dto/update-text-command.dto';
+import { QueryTextCommandDto } from './dto/query-text-command.dto';
+import { calculateExpiryDate } from '../../common/utils/date.util';
+
+@Injectable()
+export class TextCommandsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(query: QueryTextCommandDto) {
+    const { subProjectId } = query;
+
+    return this.prisma.textCommand.findMany({
+      where: {
+        isActive: true,
+        ...(subProjectId ? { subProjectId } : {}),
+      },
+      include: { subProject: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findOne(id: number) {
+    const command = await this.prisma.textCommand.findFirst({
+      where: { id, isActive: true },
+      include: { subProject: true },
+    });
+
+    if (!command) {
+      throw new NotFoundException('文字口令不存在');
+    }
+
+    return command;
+  }
+
+  async create(dto: CreateTextCommandDto) {
+    await this.ensureSubProjectExists(dto.subProjectId);
+
+    return this.prisma.textCommand.create({
+      data: {
+        subProject: { connect: { id: dto.subProjectId } },
+        commandText: dto.commandText,
+        expiryDays: dto.expiryDays,
+        expiryDate: calculateExpiryDate(dto.expiryDays) ?? undefined,
+      },
+      include: { subProject: true },
+    });
+  }
+
+  async update(id: number, dto: UpdateTextCommandDto) {
+    const command = await this.ensureExists(id);
+
+    return this.prisma.textCommand.update({
+      where: { id: command.id },
+      data: {
+        commandText: dto.commandText ?? command.commandText,
+        expiryDays: dto.expiryDays ?? command.expiryDays,
+        expiryDate:
+          dto.expiryDays !== undefined
+            ? calculateExpiryDate(dto.expiryDays) ?? undefined
+            : command.expiryDate,
+      },
+      include: { subProject: true },
+    });
+  }
+
+  async remove(id: number) {
+    await this.ensureExists(id);
+
+    await this.prisma.textCommand.update({
+      where: { id },
+      data: { isActive: false },
+    });
+
+    return { message: '文字口令删除成功' };
+  }
+
+  private async ensureExists(id: number) {
+    const command = await this.prisma.textCommand.findFirst({
+      where: { id, isActive: true },
+    });
+
+    if (!command) {
+      throw new NotFoundException('文字口令不存在');
+    }
+
+    return command;
+  }
+
+  private async ensureSubProjectExists(subProjectId: number) {
+    const subProject = await this.prisma.subProject.findFirst({
+      where: { id: subProjectId, isActive: true },
+    });
+
+    if (!subProject) {
+      throw new NotFoundException('子项目不存在');
+    }
+  }
+}

--- a/backend/src/types/api.types.ts
+++ b/backend/src/types/api.types.ts
@@ -1,0 +1,5 @@
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "noEmit": false
+  },
+  "exclude": ["test", "dist", "node_modules", "prisma/seed.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2019",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "types": ["node"],
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*", "test/**/*", "prisma/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a NestJS backend project with modules for projects, sub-projects, content types, contents, and text commands
- configure shared infrastructure including Prisma integration, common interceptors, and Swagger setup
- define Prisma schema and seed data for the CPS content management domain

## Testing
- `npm install` *(fails: 403 Forbidden fetching @nestjs/cli)*

------
https://chatgpt.com/codex/tasks/task_b_68cc3e3753948320931e8b8c1bcd05e1